### PR TITLE
fix: convert value to string before inspecting what it contains

### DIFF
--- a/packages/add-attributes-twig-extension/lib/add-attributes-twig-extension.js
+++ b/packages/add-attributes-twig-extension/lib/add-attributes-twig-extension.js
@@ -5,7 +5,7 @@ module.exports = addAttributesTwigExtension;
 function addAttributesTwigExtension(Twig) {
   Twig.extendFunction("add_attributes", function(additional_attributes = [], attributes = '') {
     attributes = [];
-  
+
     for (const [key, value] of Object.entries(additional_attributes)) {
       // If not keys array.
       if (key !== '_keys') {
@@ -15,7 +15,7 @@ function addAttributesTwigExtension(Twig) {
         }
         else {
           // Handle bem() output (pass in exactly the result).
-          if (value.includes('=')) {
+          if (String(value).includes('=')) {
             attributes.push(value);
           }
           else {
@@ -24,7 +24,7 @@ function addAttributesTwigExtension(Twig) {
         }
       }
     }
-  
+
     return attributes.join(' ');
   });
 }

--- a/packages/add-attributes-twig-extension/lib/add-attributes-twig-extension.js
+++ b/packages/add-attributes-twig-extension/lib/add-attributes-twig-extension.js
@@ -9,18 +9,24 @@ function addAttributesTwigExtension(Twig) {
     for (const [key, value] of Object.entries(additional_attributes)) {
       // If not keys array.
       if (key !== '_keys') {
-        // If multiples items in value as array (e.g., class: ['one', 'two']).
-        if (Array.isArray(value)) {
-          attributes.push(key + '="' + value.join(' ') + '"');
-        }
-        else {
-          // Handle bem() output (pass in exactly the result).
-          if (String(value).includes('=')) {
-            attributes.push(value);
-          }
-          else {
-            attributes.push(key + '="' + value + '"');
-          }
+        switch (typeof value) {
+          case 'string':
+          case 'boolean':
+          case 'number':
+            // Handle bem() output (pass in exactly the result).
+            if (value.includes('=')) {
+              attributes.push(String(value));
+            }
+            else {
+              attributes.push(key + '="' + String(value) + '"');
+            }
+            break;
+          case 'object':
+            // use Array.isArray to differentiate regular objects from arrays
+            if (Array.isArray(value)) {
+              attributes.push(key + '="' + value.join(' ') + '"');
+            }
+            break;
         }
       }
     }

--- a/packages/add-attributes-twig-extension/lib/add-attributes-twig-extension.js
+++ b/packages/add-attributes-twig-extension/lib/add-attributes-twig-extension.js
@@ -14,7 +14,7 @@ function addAttributesTwigExtension(Twig) {
           case 'boolean':
           case 'number':
             // Handle bem() output (pass in exactly the result).
-            if (value.includes('=')) {
+            if (typeof value === 'string' && value.includes('=')) {
               attributes.push(String(value));
             }
             else {


### PR DESCRIPTION
**Summary**
- https://github.com/emulsify-ds/emulsify-twig-extensions/issues/4

This PR fixes/implements the following **bugs/features**
- Allow for non-string values to be passed to the `add_attributes` function

Explain the **motivation** for making this change. What existing problem does the pull request solve?
- It's sometimes necessary to pass an integer as a value for an attribute. In particular `colspan` for `<td>` elements. Currently, this value must be converted to a string BEFORE being passed to `add_attributes()`

**Documentation Update (required)**
- none

**How to review this PR**
- [ ] Edit any component and assign some test attrbitues to a variable: 
```
{% set test_attributes = test_attributes|default({
    'colspan': 2,
  }) %}

{% set test_attributes = test_attributes|merge({
    'data-test-integer': [123, 243523],
  }) %}
```

- [ ] Call the `add_attributes` function on an element within the component
```
<div {{ add_attributes(test_attributes) }}></div>
```

- [ ] Compile storybook and Verify the storybook doesn't throw an error. In particular  `TypeError: value.includes is not a function`
- [ ] Inspect the markup and verify the above attributes are being properly rendered 
![Screenshot from 2021-11-19 10-04-10](https://user-images.githubusercontent.com/369018/142654111-2709feca-9145-4aaa-a612-1c7410989c2c.png)


**Closing issues**
https://github.com/emulsify-ds/emulsify-twig-extensions/issues/4
