### PR TITLE
fix: fix issue with includes running on numbers

### DIFF
--- a/packages/add-attributes-twig-extension/lib/add-attributes-twig-extension.js
+++ b/packages/add-attributes-twig-extension/lib/add-attributes-twig-extension.js
@@ -14,7 +14,7 @@ function addAttributesTwigExtension(Twig) {
           case 'boolean':
           case 'number':
             // Handle bem() output (pass in exactly the result).
-            if (value.includes('=')) {
+            if (typeof value === 'string' && value.includes('=')) {
               attributes.push(String(value));
             }
             else {


### PR DESCRIPTION
**Summary**
This fixes an issue where the twig extension would break because it tries to run `includes` on a number.

**How to review this PR**
- [ ] Follow the testing instructions on the PR here: https://github.com/emulsify-ds/emulsify-twig-extensions/pull/6

**Notes**
Callin - feel free to test and let me know. This outputs both strings and numbers as expected. Not sure what else that line `17` is specifically doing, but everything seems to work on my computer ©️ 

**Screenshots**
![Screen Shot 2022-11-10 at 11 40 34 AM](https://user-images.githubusercontent.com/8405274/201154689-d85ac868-5451-4cc7-8c83-42420640839e.png)