### PR TITLE
Filter BEM function classes to conform to CSS spec

### DIFF
--- a/packages/bem-twig-extension/lib/bem-twig-extension.js
+++ b/packages/bem-twig-extension/lib/bem-twig-extension.js
@@ -5,12 +5,19 @@ module.exports = bemTwigExtension;
 function bemTwigExtension(Twig) {
   Twig.extendFunction("bem", function(base_class, modifiers = [], blockname = '', extra = [], attributes = '') {
     let classes = [];
-    
+
+    // Helper function to sanitize and validate class names
+    function sanitizeClassName(className) {
+      // Strips out initial numbers. Replace non-matches with spaces, does strip non-english characters
+      const sanitized = className.match(/-?[_a-zA-Z]+[_a-zA-Z0-9-]*/g);
+      return sanitized ? sanitized.join(' ') : '';
+    }
+
     // If using a blockname to override default class.
     if (blockname.length) {
         // Set blockname class.
         classes.push(blockname + '__' + base_class);
-    
+
         // Set blockname--modifier classes for each modifier.
         if (modifiers.length && Array.isArray(modifiers)) {
         modifiers.forEach(function(modifier) {
@@ -29,14 +36,19 @@ function bemTwigExtension(Twig) {
         });
         }
     }
-    
+
     // If extra non-BEM classes are added.
     if (extra.length && Array.isArray(extra)) {
         extra.forEach(function(extra_class) {
         classes.push(extra_class);
         });
     }
-    
+
+    // Sanitize class names in the classes array
+    classes = classes.map(function(className) {
+        return sanitizeClassName(className);
+    });
+
     attributes = 'class="' + classes.join(' ') + '"';
     return attributes;
   });


### PR DESCRIPTION
## Summary

This PR fixes/implements the following **bugs/features**

- Filters classes passed to the `bem` function to conform to the CSS class specifications listed here: https://www.w3.org/TR/CSS21/syndata.html#characters
- This filter will replace invalid characters with spaces. For example: a class of `my^selector` would output `my selector` as the class names.
- It is not likely, but there are possibly breaking changes if class names were using invalid characters that were expected in the output.

Explain the **motivation** for making this change. What existing problem does the pull request solve?

Class names should conform to the CSS specification and this function is outputting generated classes. Each of these generated classes should behave within the spec.

## Documentation update (required)

Documentation should be added for the `bem` function.

## How to review this pull request

- [ ] Start Storybook instance, `npm run storybook`
- [ ] Edit a component twig file, such as a basic text field component
- [ ] When using the `bem` function, pass in some class names that are and aren't valid, for example:

```
{% set text_field__base_class = text_field__base_class|default('text-field') %}
{% set text_field__extra_classes = ['good-class-name', 'with^carrot', 'with_underscore', 'with%percent', 'with()parens'] %}
{% set text_field__attributes = {
  class: bem(text_field__base_class, text_field__modifiers, text_field__blockname, text_field__extra_classes),
} %}

<div {{ add_attributes(text_field__attributes) }}>
  {% block prefix_suffix %}
  {% endblock %}
  <div {{ bem('inner', [], text_field__base_class) }}>
    {% include "@atoms/typography/text/yds-text.twig" with {
      text__content: text_field__content,
    } %}
  </div>
</div>
```
- [ ] Verify that the output in the DOM has replaced the `^`, `%`, and `()` with spaces.
- [ ] Verify that the `good-class-name` and `with_underscore` are unmodified.
- [ ] Change the base class in the example above to `2text-field` and verify that the `2` gets stripped out.

┆Issue is synchronized with this [Clickup task](https://app.clickup.com/t/86a2fe30d) by [Unito](https://www.unito.io)
